### PR TITLE
Specify daemon host

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ![demo](https://thumbs.gfycat.com/JitteryHealthyAmericanshorthair-size_restricted.gif) 
 * Open DockerTools Panel with `:DockerToolsOpen`, close it with `:DockerToolsClose`
 * Toggle DockerTools Panel with `:DockerToolsToggle`
+* Set Docker daemon host with `:DockerToolsSetHost`
 * Support `:ContainerStart`, `:ContainerStop`, `:ContainerRemove`, `:ContainerRestart`, `:ContainerPause`, `:ContainerUnpause`, `ContainerLogs`. For details please check out the documentation (`:help docker-tools-commands`).
 * Autocompletion for container commands
 * Full documentation in `:help vim-docker-tools`

--- a/autoload/docker_tools.vim
+++ b/autoload/docker_tools.vim
@@ -37,7 +37,7 @@ function! docker_tools#dt_toggle() abort
 endfunction
 
 function! docker_tools#dt_set_host(...) 
-	if a:0 
+	if a:0 == 1
 		let g:dockertools_docker_cmd = join(['docker -H', a:1], ' ')
 	else
 		let g:dockertools_docker_cmd = 'docker'

--- a/autoload/docker_tools.vim
+++ b/autoload/docker_tools.vim
@@ -37,7 +37,7 @@ function! docker_tools#dt_toggle() abort
 endfunction
 
 function! docker_tools#dt_set_host(...) 
-	if a:0 == 1
+	if a:0 == 1 && a:1 != ''
 		let g:dockertools_docker_cmd = join(['docker -H', a:1], ' ')
 	else
 		let g:dockertools_docker_cmd = 'docker'

--- a/autoload/docker_tools.vim
+++ b/autoload/docker_tools.vim
@@ -37,7 +37,7 @@ function! docker_tools#dt_toggle() abort
 endfunction
 
 function! docker_tools#dt_set_host(...) 
-	if a:0 == 1 && a:1 != ''
+	if a:0 == 1 && (index(["''",'""',''], a:1)) == -1
 		let g:dockertools_docker_cmd = join(['docker -H', a:1], ' ')
 	else
 		let g:dockertools_docker_cmd = 'docker'

--- a/doc/vim-docker-tools.txt
+++ b/doc/vim-docker-tools.txt
@@ -59,6 +59,11 @@ COMMANDS                                               *docker-tools-commands*
 
 	  Toggle between |:DockerToolsOpen| and |:DockerToolsClose|.
 
+                                                          *:DockerToolsSetHost*
+:DockerToolsSetHost [host_url]
+
+    Set the host URL for the docker daemon.
+
                                                              *:ContainerStart*
 :ContainerStart [container] [options]
 
@@ -146,6 +151,20 @@ Use this option to set the logs window size. Default value: 30
 Show all or running containers only by default. Default value: 1
 >
   let g:dockertools_default_all = 1
+<
+
+                                                   *'g:dockertools_docker_host'*
+
+Use this option to set the default host string for docker. Default value: 
+>
+  let g:dockertoosl_docker_host = 
+<
+
+                                                   *'g:dockertools_docker_cmd'*
+
+The prefix to use for the docker cli. Default value: docker
+>
+  let g:dockertools_docker_cmd = 'docker'
 <
 ==============================================================================
 CONTRIBUTING                                       *docker-tools-contributing*

--- a/plugin/vim-docker-tools.vim
+++ b/plugin/vim-docker-tools.vim
@@ -18,9 +18,14 @@ if !exists('g:dockertools_default_all')
 	let g:dockertools_default_all = 1
 endif
 
+if exists('g:dockertools_docker_host')
+	call docker_tools#dt_set_host(g:dockertools_docker_host)
+endif
+
 command! DockerToolsOpen call docker_tools#dt_open()
 command! DockerToolsClose call docker_tools#dt_close()
 command! DockerToolsToggle call docker_tools#dt_toggle()
+command! -nargs=? DockerToolsSetHost call docker_tools#dt_set_host(<q-args>)
 command! -complete=customlist,docker_tools#Complete -nargs=+ ContainerStart call docker_tools#container_action('start',<f-args>)
 command! -complete=customlist,docker_tools#Complete -nargs=+ ContainerStop call docker_tools#container_action('stop',<f-args>)
 command! -complete=customlist,docker_tools#Complete -nargs=+ ContainerRemove call docker_tools#container_action('rm',<f-args>)


### PR DESCRIPTION
Let users target the docker daemon via URL, defaulting to the local configuration if no host is set. 

g:dockertools_docker_host can be set in the deploy.yaml to automatically set the daemon url

:DockerToolsSetHost tcp://host-url:host-port or :DockerToolsSetHost unix:///var/run/docker.sock can be used to set the host. 

All docker cli calls are prefixed with the value of g:dockertools_docker_cmd.

On start if the docker host has been set the variable g:dockertools_docker_cmd is set to `docker -H g:dockertools_docker_host` where g:dockertools_docker_host is substituted with the value of the variable , if no value has been set for g:dockertools_docker_host g:dockertools_docker_cmd is set to `docker`.

If the DockerToolsSetHost command is used, the g:dockertools_docker_cmd is then set to the value `docker -H a:1` where a:1 is substituted with the value of the host URL argument.

This does not support specifying the authentication mode / certificates used by the client due to the complexities of handling all the different [client authentication modes](https://docs.docker.com/engine/security/https/#client-modes) but secure sessions will still work if the users environment is configured correctly for them. Handling of authentication and the certificates for the client would make for a good feature addition in the future though. 

Tested on my local machine, targeting the locally running docker daemon using both a unix and tcp socket, as well as remote hosts using their tcp sockets. For each socket tested (local unix, local tcp, remote tcp), setting the socket was tested via setting from a variable in my .vimrc, and by using the :DockerToolsSetHost command. 