### PR TITLE
Container filtering

### DIFF
--- a/autoload/docker_tools.vim
+++ b/autoload/docker_tools.vim
@@ -297,7 +297,7 @@ function! s:sudo_mode() abort
 	return ['','sudo '][g:dockertools_sudo_mode]
 endfunction
 "}}}
-"global vars {{{
+"referal vars {{{
 let s:ps_filters  = ['id', 'name', 'label', 'exited', 'status', 'ancestor', 'before', 'since', 'volume', 'network', 'publish', 'expose', 'health', 'isolation', 'is-task']
 "}}}
 " vim: fdm=marker:

--- a/autoload/docker_tools.vim
+++ b/autoload/docker_tools.vim
@@ -48,11 +48,11 @@ function! docker_tools#dt_set_filter(filters) abort
 	"validate the filter keys
 	"expect filters to be space delimited
 	"expect key value to be '=' delimited
-	let l:filters = '-f'
+	let l:filters = ''
 	for l:ps_filter in split(a:filters, ' ')
 		let l:filter_components = split(l:ps_filter, '=')
 		if index(s:ps_filters, filter_components[0]) > -1
-			let l:filters = join([l:filters, l:ps_filter], ' ')
+			let l:filters = join([l:filters, '-f', l:ps_filter], ' ')
 		endif
 	endfor
 	let g:dockertools_ps_filter = l:filters

--- a/autoload/docker_tools.vim
+++ b/autoload/docker_tools.vim
@@ -59,6 +59,10 @@ function! docker_tools#dt_set_filter(filters) abort
 	if '-f' == g:dockertools_ps_filter
 		let g:dockertools_ps_filter = ''
 	endif
+
+	if exists('g:vdocker_windowid')
+		call s:dt_ui_load()
+	endif
 endfunction
 "}}}
 "docker tools commands{{{

--- a/doc/vim-docker-tools.txt
+++ b/doc/vim-docker-tools.txt
@@ -64,6 +64,14 @@ COMMANDS                                                 *docker-tools-commands*
 
     Set the host URL for the docker daemon.
 
+                                                           *:DockerToolsSetFilter*
+:DockerToolsSetFilter [filters]
+
+    Set the filters to be used when displaying containers. This follows the
+    same format as the filter flag used by the `docker ps` command.
+    An empty string will remove all currently active filters
+    Invalid filter keys will be dropped from the filter.
+
                                                                *:ContainerStart*
 :ContainerStart [container] [options]
 
@@ -104,6 +112,7 @@ MAPPINGS                                                 *docker-tools-mappings*
 
   	DockerTools Mapping  | Details
     ---------------------|----------------------------------------------
+    f                    | Set container filters.
     s                    | Start container.
     d                    | Stop container.
     r                    | Restart container.
@@ -193,10 +202,15 @@ The prefix to use for the docker cli. Default value: docker
 >
   let g:dockertools_docker_cmd = 'docker'
 <
+                                                   *'g:dockertools_ps_filter'*
+
+The filter to use when displaying containers. Default value: ''
+>
+  let g:dockertools_ps_filter = 'name=my_container'
+<
 
 ================================================================================
 CONTRIBUTING                                         *docker-tools-contributing*
->>>>>>> e28d09000894febd562c50a3a7caa101bf151c14
 
 Bug reports, feature requests and pull requests are all welcome!
 

--- a/doc/vim-docker-tools.txt
+++ b/doc/vim-docker-tools.txt
@@ -72,6 +72,11 @@ COMMANDS                                                 *docker-tools-commands*
     An empty string will remove all currently active filters
     Invalid filter keys will be dropped from the filter.
 
+                                                           *:DockerToolsClearFilter*
+:DockerToolsClearFilter [filters]
+
+    Clears the filter being used for displaying containers.
+
                                                                *:ContainerStart*
 :ContainerStart [container] [options]
 

--- a/plugin/vim-docker-tools.vim
+++ b/plugin/vim-docker-tools.vim
@@ -32,9 +32,17 @@ else
 	call docker_tools#dt_set_host()
 endif
 
+if !exists('g:dockertools_ps_filter')
+	let g:dockertools_ps_filter = ''
+else
+	call docker_tools#dt_set_filter(g:dockertools_ps_filter)
+endif
+
 command! DockerToolsOpen call docker_tools#dt_open()
 command! DockerToolsClose call docker_tools#dt_close()
 command! DockerToolsToggle call docker_tools#dt_toggle()
+command! DockerToolsClearFilter call docker_tools#dt_set_filter('')
+command! -nargs=* DockerToolsSetFilter call docker_tools#dt_set_filter(<q-args>)
 command! -nargs=? DockerToolsSetHost call docker_tools#dt_set_host(<q-args>)
 command! -complete=customlist,docker_tools#complete -nargs=+ ContainerStart call docker_tools#container_action('start',<f-args>)
 command! -complete=customlist,docker_tools#complete -nargs=+ ContainerStop call docker_tools#container_action('stop',<f-args>)


### PR DESCRIPTION
Added filtering capabilities for docker containers as per #5 . This builds off of the `-f` flag used in the `docker ps` command, and is configurable in the .vimrc file, via the DockerToolsSetFilter command, DockerToolsClearFilter command, and with the f key when the cursor is located in the ui.

If the ui is open when a filter is set (or cleared) than the ui will automatically reload with the new filter settings. 

Any invalid filter keys (those that are not in the docker documentation) will be automatically removed from the filters, so errors are less prevalent when viewing the containers. 

The documentation has been updated with the new commands and settings. 

Tested locally with single and multiple filters, both set from my .vimrc file, via the DockerToolsSetFilter command, and the DockerToolsClearFilter command. As well all tests were done with the ui opened during the command execution, and the ui closed during the command execution. 