### PR TITLE
Add reload key

### DIFF
--- a/autoload/docker_tools.vim
+++ b/autoload/docker_tools.vim
@@ -28,6 +28,10 @@ function! docker_tools#dt_close() abort
 	endif
 endfunction
 
+function! docker_tools#dt_reload() abort
+		call s:dt_ui_load()
+endfunction
+
 function! docker_tools#dt_toggle() abort
 	if !exists('g:vdocker_windowid')
 		call docker_tools#dt_open()
@@ -118,6 +122,7 @@ function! s:dt_set_mapping() abort
 		nnoremap <buffer> <silent> d :call docker_tools#dt_action('stop')<CR>
 		nnoremap <buffer> <silent> x :call docker_tools#dt_action('rm')<CR>
 		nnoremap <buffer> <silent> r :call docker_tools#dt_action('restart')<CR>
+		nnoremap <buffer> <silent> R :call docker_tools#dt_reload()<CR>
 		nnoremap <buffer> <silent> p :call docker_tools#dt_action('pause')<CR>
 		nnoremap <buffer> <silent> u :call docker_tools#dt_action('unpause')<CR>
 		nnoremap <buffer> <silent> > :call docker_tools#dt_run_command()<CR>
@@ -152,6 +157,7 @@ function! s:dt_get_help() abort
 	let help .= "# s: start container\n"
 	let help .= "# d: stop container\n"
 	let help .= "# r: restart container\n"
+	let help .= "# R: reload container data\n"
 	let help .= "# x: delete container\n"
 	let help .= "# p: pause container\n"
 	let help .= "# u: unpause container\n"

--- a/doc/vim-docker-tools.txt
+++ b/doc/vim-docker-tools.txt
@@ -107,6 +107,7 @@ MAPPINGS                                                 *docker-tools-mappings*
     s                    | Start container.
     d                    | Stop container.
     r                    | Restart container.
+    R                    | Reload current container data.
     x                    | Delete container.
     p                    | Pause container.
     u                    | Unpause container.


### PR DESCRIPTION
Added a mapping to call s:dt_ui_load from within the ui using 'R' and updated the documentation for the mapping. Tested locally, verifying that a recently created container had it's created time updated to a new seconds count on refresh (for example going from 20 seconds ago to 21 seconds ago). 'R' was chosen over 'r' as 'r' already had a binding. 

In regards to issue #17 
