### PR TITLE
Alternative mappings

### DIFF
--- a/autoload/docker_tools.vim
+++ b/autoload/docker_tools.vim
@@ -139,19 +139,19 @@ function! s:dt_get_id() abort
 endfunction
 
 function! s:dt_set_mapping() abort
-		nnoremap <buffer> <silent> q :DockerToolsClose<CR>
-		nnoremap <buffer> <silent> s :call docker_tools#dt_action('start')<CR>
-		nnoremap <buffer> <silent> d :call docker_tools#dt_action('stop')<CR>
-		nnoremap <buffer> <silent> x :call docker_tools#dt_action('rm')<CR>
-		nnoremap <buffer> <silent> r :call docker_tools#dt_action('restart')<CR>
-		nnoremap <buffer> <silent> p :call docker_tools#dt_action('pause')<CR>
-		nnoremap <buffer> <silent> u :call docker_tools#dt_action('unpause')<CR>
-		nnoremap <buffer> <silent> > :call docker_tools#dt_run_command()<CR>
-		nnoremap <buffer> <silent> < :call docker_tools#dt_logs()<CR>
-		nnoremap <buffer> <silent> a :call docker_tools#dt_toggle_all()<CR>
-		nnoremap <buffer> <silent> R :call docker_tools#dt_reload()<CR>
-		nnoremap <buffer> <silent> ? :call docker_tools#dt_toggle_help()<CR>
-		nnoremap <buffer> <silent> f :call docker_tools#dt_ui_set_filter()<CR>
+	execute 'nnoremap <buffer> <silent>' . g:dockertools_key_mapping['container-start'] . ' :call docker_tools#dt_action("start")<CR>'
+	execute 'nnoremap <buffer> <silent>' . g:dockertools_key_mapping['container-stop'] . ' :call docker_tools#dt_action("stop")<CR>'
+	execute 'nnoremap <buffer> <silent>' . g:dockertools_key_mapping['container-delete'] . ' :call docker_tools#dt_action("rm")<CR>'
+	execute 'nnoremap <buffer> <silent>' . g:dockertools_key_mapping['container-restart'] . ' :call docker_tools#dt_action("restart")<CR>'
+	execute 'nnoremap <buffer> <silent>' . g:dockertools_key_mapping['container-pause'] . ' :call docker_tools#dt_action("pause")<CR>'
+	execute 'nnoremap <buffer> <silent>' . g:dockertools_key_mapping['container-unpause'] . ' :call docker_tools#dt_action("unpause")<CR>'
+	execute 'nnoremap <buffer> <silent>' . g:dockertools_key_mapping['container-execute'] . ' :call docker_tools#dt_run_command()<CR>'
+	execute 'nnoremap <buffer> <silent>' . g:dockertools_key_mapping['container-show-logs'] . ' :call docker_tools#dt_logs()<CR>'
+	execute 'nnoremap <buffer> <silent>' . g:dockertools_key_mapping['ui-close'] . ' :DockerToolsClose<CR>'
+	execute 'nnoremap <buffer> <silent>' . g:dockertools_key_mapping['ui-toggle-all'] . ' :call docker_tools#dt_toggle_all()<CR>'
+	execute 'nnoremap <buffer> <silent>' . g:dockertools_key_mapping['ui-reload'] . ' :call docker_tools#dt_reload()<CR>'
+	execute 'nnoremap <buffer> <silent>' . g:dockertools_key_mapping['ui-toggle-help'] . ' :call docker_tools#dt_toggle_help()<CR>'
+	execute 'nnoremap <buffer> <silent>' . g:dockertools_key_mapping['ui-filter'] . ' :call docker_tools#dt_ui_set_filter()<CR>'
 endfunction
 
 function! s:dt_ui_load() abort
@@ -177,18 +177,19 @@ endfunction
 function! s:dt_get_help() abort
 	let help = "# vim-docker-tools quickhelp\n"
 	let help .= "# ------------------------------------------------------------------------------\n"
-	let help .= "# f: set container filter\n"
-	let help .= "# s: start container\n"
-	let help .= "# d: stop container\n"
-	let help .= "# r: restart container\n"
-	let help .= "# x: delete container\n"
-	let help .= "# p: pause container\n"
-	let help .= "# u: unpause container\n"
-	let help .= "# >: execute command to container\n"
-	let help .= "# <: show container logs\n"
-	let help .= "# a: toggle show all/running containers\n"
-	let help .= "# R: refresh container status\n"
-	let help .= "# ?: toggle help\n"
+	let help .= "# " . g:dockertools_key_mapping['container-start'] . ": start container\n"
+	let help .= "# " . g:dockertools_key_mapping['container-stop'] . ": stop container\n"
+	let help .= "# " . g:dockertools_key_mapping['container-restart'] . ": restart container\n"
+	let help .= "# " . g:dockertools_key_mapping['container-delete'] . ": delete container\n"
+	let help .= "# " . g:dockertools_key_mapping['container-pause'] . ": pause container\n"
+	let help .= "# " . g:dockertools_key_mapping['container-unpause'] . ": unpause container\n"
+	let help .= "# " . g:dockertools_key_mapping['container-execute'] . ": execute command to container\n"
+	let help .= "# " . g:dockertools_key_mapping['container-show-logs'] . ": show container logs\n"
+	let help .= "# " . g:dockertools_key_mapping['ui-close'] . ": close vim-docker-tools\n"
+	let help .= "# " . g:dockertools_key_mapping['ui-filter'] . ": set container filter\n"
+	let help .= "# " . g:dockertools_key_mapping['ui-reload'] . ": refresh container status\n"
+	let help .= "# " . g:dockertools_key_mapping['ui-toggle-all'] . ": toggle show all/running containers\n"
+	let help .= "# " . g:dockertools_key_mapping['ui-toggle-help'] . ": toggle help\n"
 	let help .= "# ------------------------------------------------------------------------------\n"
 	silent! put =help
 endfunction

--- a/autoload/docker_tools.vim
+++ b/autoload/docker_tools.vim
@@ -172,10 +172,10 @@ function! s:dt_get_help() abort
 	let help .= "# " . g:dockertools_key_mapping['container-unpause'] . ": unpause container\n"
 	let help .= "# " . g:dockertools_key_mapping['container-execute'] . ": execute command to container\n"
 	let help .= "# " . g:dockertools_key_mapping['container-show-logs'] . ": show container logs\n"
-  let help .= "# " . g:dockertools_key_mapping['ui-toggle-all'] . ": toggle show all/running containers\n"
+	let help .= "# " . g:dockertools_key_mapping['ui-toggle-all'] . ": toggle show all/running containers\n"
 	let help .= "# " . g:dockertools_key_mapping['ui-filter'] . ": set container filter\n"
 	let help .= "# " . g:dockertools_key_mapping['ui-reload'] . ": refresh container status\n"
-  let help .= "# " . g:dockertools_key_mapping['ui-close'] . ": close vim-docker-tools\n"
+	let help .= "# " . g:dockertools_key_mapping['ui-close'] . ": close vim-docker-tools\n"
 	let help .= "# " . g:dockertools_key_mapping['ui-toggle-help'] . ": toggle help\n"
 	let help .= "# ------------------------------------------------------------------------------\n"
 	silent! put =help

--- a/doc/vim-docker-tools.txt
+++ b/doc/vim-docker-tools.txt
@@ -7,7 +7,7 @@ CONTENTS                                                 *docker-tools-contents*
   1. Intro........................................|docker-tools-intro|
   2. Install......................................|docker-tools-install|
   3. Commands.....................................|docker-tools-commands|
-  4. Mapping......................................|docker-tools-mapping|
+  4. Mappings.....................................|docker-tools-mappings|
   5. Settings.....................................|docker-tools-settings|
   6. Contributing.................................|docker-tools-contributing|
 

--- a/doc/vim-docker-tools.txt
+++ b/doc/vim-docker-tools.txt
@@ -7,7 +7,7 @@ CONTENTS                                                 *docker-tools-contents*
   1. Intro........................................|docker-tools-intro|
   2. Install......................................|docker-tools-install|
   3. Commands.....................................|docker-tools-commands|
-  4. Mappings.....................................|docker-tools-mappings|
+  4. Mapping......................................|docker-tools-mapping|
   5. Settings.....................................|docker-tools-settings|
   6. Contributing.................................|docker-tools-contributing|
 
@@ -113,22 +113,23 @@ COMMANDS                                                 *docker-tools-commands*
 	  Show container logs.
 
 ================================================================================
-MAPPINGS                                                 *docker-tools-mappings*
+Mapping                                                   *docker-tools-mapping*
 
-  	DockerTools Mapping  | Details
-    ---------------------|----------------------------------------------
-    f                    | Set container filters.
-    s                    | Start container.
-    d                    | Stop container.
-    r                    | Restart container.
-    x                    | Delete container.
-    p                    | Pause container.
-    u                    | Unpause container.
-    >                    | Execute command to container.
-    <                    | Show container logs.
-    a                    | Toggle show all/running containers.
-    R                    | Refresh container status.
-    ?                    | Toggle help.
+  	DockerTools Default | Mapping Dict Key    | Details
+    ------------------- | ------------------- | ------------------------------
+    s                   | container-start     | Start container.
+    S                   | container-stop      | Stop container.
+    R                   | container-restart   | Restart container.
+    d                   | container-delete    | Delete container.
+    p                   | container-pause     | Pause container.
+    P                   | container-unpause   | Unpause container.
+    !                   | container-execute   | Execute command to container.
+    <CR>                | container-show-logs | Show container logs.
+    a                   | ui-toggle-all       | Toggle show all/running containers.
+    ?                   | ui-toggle-help      | Toggle help.
+    f                   | ui-filter           | Set container filters.
+    r                   | ui-reload           | Refresh container status.
+    q                   | ui-close            | Close current DockerTools window.
 
 ================================================================================
 SETTINGS                                                 *docker-tools-settings*
@@ -214,6 +215,17 @@ The filter to use when displaying containers. Default value: ''
 >
   let g:dockertools_ps_filter = 'name=my_container'
 <
+
+                                                   *'g:dockertools_user_key_mapping'*
+
+A dictionary of key mapping used to override the default settings. Default value: unset
+>
+  let g:dockertools_user_key_mapping = {'ui_filter' : 'F'}
+<
+
+See |docker-tools-mapping| for a list of valid keys, and their default
+settings.
+
 
 ================================================================================
 CONTRIBUTING                                         *docker-tools-contributing*

--- a/doc/vim-docker-tools.txt
+++ b/doc/vim-docker-tools.txt
@@ -102,7 +102,7 @@ COMMANDS                                                 *docker-tools-commands*
 ================================================================================
 MAPPINGS                                                 *docker-tools-mappings*
 
-  	DockerTools Default | Mapping Dict Key    | Details
+    DockerTools Default | Mapping Dict Key    | Details
     ------------------- | ------------------- | ------------------------------
     s                   | container-start     | Start container.
     d                   | container-stop      | Stop container.

--- a/plugin/vim-docker-tools.vim
+++ b/plugin/vim-docker-tools.vim
@@ -1,3 +1,5 @@
+let s:default_key_mapping = {'container-start' : 's', 'container-stop' : 'S', 'container-restart' : 'R', 'container-delete' : 'd', 'container-pause' : 'p', 'container-unpause' : 'P', 'container-execute' : '!', 'container-show-logs' : '<CR>', 'ui-toggle-all' : 'a', 'ui-reload' : 'r', 'ui-close' : 'q', 'ui-toggle-help' : '?', 'ui-filter' : 'f'}
+
 if !exists('g:dockertools_size')
 	let g:dockertools_size = 15
 endif
@@ -36,6 +38,12 @@ if !exists('g:dockertools_ps_filter')
 	let g:dockertools_ps_filter = ''
 else
 	call docker_tools#dt_set_filter(g:dockertools_ps_filter)
+endif
+
+if exists('g:dockertools_user_key_mapping')
+	let g:dockertools_key_mapping = extend(s:default_key_mapping, g:dockertools_user_key_mapping) 
+else
+	let g:dockertools_key_mapping = s:default_key_mapping
 endif
 
 command! DockerToolsOpen call docker_tools#dt_open()


### PR DESCRIPTION
re: #19
Add configuration for users to set their own mappings via a dictionary in their .vimrc .
Default mappings updated to those requested in #19 , but I'm not opposed to reverting any/all to their old mappings if preferred

The documentation has also been updated with the new keys, the dictionary key to use for custom settings, and details on setting the g:dockertools_user_key_mapping variable.

As well there was some inconsistency with the use of mappings vs mapping so I refractored everything to use mapping instead of mappings 

I tried changing pause-container to be a toggle to go between pause / unpause, but it would require some extra functionality to silently determine the current state of the container so the proper command could be ran, which led down a rabbit hole that would be out of scope for this change. 

As always tested locally. With the mapping unmodified from the default, as well as the mapping modified from the default in my .vimrc file. 